### PR TITLE
Add Clock screen, side menu and navigation to Calculator

### DIFF
--- a/TestApp/ContentView.swift
+++ b/TestApp/ContentView.swift
@@ -8,6 +8,134 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var isMenuVisible = false
+    @State private var path: [Route] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ZStack(alignment: .leading) {
+                ClockView()
+                    .disabled(isMenuVisible)
+                    .blur(radius: isMenuVisible ? 1 : 0)
+                    .overlay {
+                        if isMenuVisible {
+                            Color.black.opacity(0.25)
+                                .ignoresSafeArea()
+                                .onTapGesture {
+                                    withAnimation(.easeInOut) {
+                                        isMenuVisible = false
+                                    }
+                                }
+                        }
+                    }
+
+                SideMenuView(
+                    isVisible: $isMenuVisible,
+                    onSelectCalculator: {
+                        withAnimation(.easeInOut) {
+                            isMenuVisible = false
+                        }
+                        path.append(.calculator)
+                    },
+                    onSelectClock: {
+                        withAnimation(.easeInOut) {
+                            isMenuVisible = false
+                        }
+                    }
+                )
+            }
+            .navigationTitle("Ceas")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button {
+                        withAnimation(.easeInOut) {
+                            isMenuVisible.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "line.3.horizontal")
+                    }
+                    .accessibilityLabel("Open menu")
+                }
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .calculator:
+                    CalculatorView()
+                        .navigationTitle("Calculator")
+                }
+            }
+        }
+    }
+}
+
+private enum Route: Hashable {
+    case calculator
+}
+
+private struct SideMenuView: View {
+    @Binding var isVisible: Bool
+    let onSelectCalculator: () -> Void
+    let onSelectClock: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Meniu")
+                .font(.headline)
+                .padding(.top, 40)
+
+            Button("Calculator", action: onSelectCalculator)
+                .font(.title3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button("Ceas", action: onSelectClock)
+                .font(.title3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer()
+        }
+        .padding(.horizontal, 24)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .frame(width: 260)
+        .background(Color(.systemBackground))
+        .offset(x: isVisible ? 0 : -260)
+        .shadow(color: Color.black.opacity(0.2), radius: 8, x: 2, y: 0)
+        .animation(.easeInOut, value: isVisible)
+    }
+}
+
+private struct ClockView: View {
+    @State private var now = Date()
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, d MMMM"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(Self.timeFormatter.string(from: now))
+                .font(.system(size: 56, weight: .bold, design: .rounded))
+
+            Text(Self.dateFormatter.string(from: now))
+                .font(.title3)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemGroupedBackground))
+        .onReceive(timer) { date in
+            now = date
+        }
+    }
+}
+
+private struct CalculatorView: View {
     @State private var displayText = "0"
     @State private var storedValue: Double? = nil
     @State private var pendingOperation: Operation? = nil


### PR DESCRIPTION
### Motivation
- Launch the app on a live clock screen that shows current time/date and updates in real time for a cleaner primary experience.
- Provide a hamburger-triggered side menu so users can quickly navigate to the existing calculator screen.
- Keep the existing calculator UI/logic unchanged while integrating it into the new navigation flow.

### Description
- Replace the root view with a `NavigationStack` that hosts `ClockView` and a leading hamburger `Button` which toggles `SideMenuView`.
- Add `SideMenuView` that slides in from the left with an animation and exposes actions for `Calculator` and `Ceas` items, where selecting `Calculator` appends `Route.calculator` to the navigation `path` and closes the menu.
- Implement `ClockView` using `Timer.publish(every: 1, on: .main, in: .common).autoconnect()` with `DateFormatter`s to display `HH:mm:ss` and a readable date string updated every second.
- Move the existing calculator UI into a `CalculatorView` in the same file and register it as a `navigationDestination` with the navigation title set to `Calculator` while keeping the calculator behavior intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ca7969f808332ab8b2aa2e1399c80)